### PR TITLE
Update dependencies and complete CherriLog feature enhancements

### DIFF
--- a/.develop/pull-requests/reply-#15.md
+++ b/.develop/pull-requests/reply-#15.md
@@ -1,0 +1,118 @@
+# Copilot Review Replies for PR #15
+
+---
+
+### Suggestion 1–5 (wrapper.dart — auto stackTrace on every log)
+
+**Copilot concern:** `StackTrace.current` is captured for every log level, causing noise and performance overhead.
+
+**Fix:**
+
+- `fatal()` and `error()` retain `stackTrace ?? StackTrace.current` fallback — errors deserve full context.
+- `warning()`, `info()`, `debug()` removed the fallback — they now pass `stackTrace` directly. No stack trace is captured unless the caller explicitly provides one.
+- Users can still opt in at any level by passing `stackTrace: StackTrace.current`.
+
+**Files:** `lib/wrapper.dart`
+
+---
+
+### Suggestion 6 (message.dart — error line misaligned in align mode)
+
+**Copilot concern:** In `StackTraceStyle.align` mode the error line is emitted without the same right-padding as stack frames.
+
+**Fix:**
+
+- Added `else if (autoFormatTrace)` branch: error line now aligned with `' ' * aheadLength` in align mode, matching stack frame indentation.
+- Full three-way: `tab` → `\t`, `align` → right-padded spaces, otherwise → no indent.
+
+**Files:** `lib/formatter/message.dart`
+
+---
+
+### Suggestion 7 & 8 (template.dart — manual JSON construction)
+
+**Copilot concern:** JSON is hand-built with a custom escape function, which risks invalid JSON. `stackTrace` is also omitted from JSON output.
+
+**Fix:**
+
+- Replaced `_formatJson()` and `_escapeJson()` with `dart:convert`'s `jsonEncode()` on a `Map<String, String>`.
+- Added `stackTrace` to the JSON output via `_formatStackTrace()`.
+- Guarantees correct escaping, shorter code, and no missing fields.
+
+**Files:** `lib/formatter/template.dart`
+
+---
+
+### Suggestion 9 (template.dart — `stackTraceStyle.align` behaves like no-indent)
+
+**Copilot concern:** In template mode, `StackTraceStyle.align` produces no indentation at all, making the option effectively ignored outside `tab`.
+
+**Fix:**
+
+- `align` mode now uses a 4-space indent (`'    '`) in template formatter.
+- `tab` mode continues to use `\t`.
+- When `autoFormatTrace` is false, no indent (as before).
+
+**Files:** `lib/formatter/template.dart`
+
+---
+
+### Suggestion 10 (options.dart — unresolved doc reference)
+
+**Copilot concern:** `[CherriFormatterMessageTemplate]` in the doc comment references a symbol not imported in this file.
+
+**Fix:**
+
+- Added `import 'package:cherrilog/formatter/template.dart';` to `lib/model/options.dart`.
+
+**Files:** `lib/model/options.dart`
+
+---
+
+### Suggestion 11 (logger_file.dart — misleading Web doc)
+
+**Copilot concern:** The `defaultLocation` doc implies `CherriFile` works on Web, but it imports `dart:io` and cannot compile there.
+
+**Fix:**
+
+- Updated the doc table: Web and mobile were split into separate entries. Web is now explicitly marked **Not available**.
+- Wrote a companion analysis at `.develop/suggestions/web-platform-support.md` discussing three approaches (conditional exports, dropping `web:` from platforms, sub-packages) with a recommendation.
+
+**Files:** `lib/logger/loggers/logger_file.dart`, `.develop/suggestions/web-platform-support.md`
+
+---
+
+### Suggestion 12 (logger_file.dart — maxFilesCount enforced unconditionally)
+
+**Copilot concern:** File-count capping runs regardless of `clearMode`, contradicting the doc that says cleanup is "according to the configured `clearMode`".
+
+**Fix:**
+
+- Added `CherriFileClearMode.maxFileCount = 4` flag.
+- Wrapped the file-count cleanup block with `if ((clearMode & maxFileCount) != 0)`.
+- Updated the default `clearMode` to include the new flag: `oldFiles | outSizedFiles | maxFileCount`.
+- All three cleanup dimensions are now independently gated by their flags.
+
+**Files:** `lib/logger/loggers/logger_file.dart`
+
+---
+
+### Suggestion 13 & 14 (tests — no assertions)
+
+**Copilot concern:** The new `StackTraceStyle` tests only emit output without any assertions, so regressions won't be caught.
+
+**Fix:**
+
+- Kept the existing `error()` calls for human-visible console output.
+- Added direct formatter assertions using `CherriFormatterMessageDefault`:
+  - `align` test verifies at least one frame line starts with ≥20 spaces (right-padding).
+  - `tab` test verifies every frame line from this test file starts with `\t`.
+- `CherriMessage` was previously not publicly exported — added `export 'package:cherrilog/model/message.dart'` to `lib/cherrilog.dart`.
+
+**Files:** `test/cherrilog_test.dart`, `lib/cherrilog.dart`
+
+---
+
+### Bonus cleanup
+
+- Removed two now-redundant `import 'package:cherrilog/model/message.dart'` from `lib/logger/logger.dart` and `lib/wrapper.dart` (now provided by `cherrilog.dart` re-export).

--- a/lib/cherrilog.dart
+++ b/lib/cherrilog.dart
@@ -7,6 +7,8 @@ import 'package:cherrilog/model/message.dart';
 export 'package:cherrilog/cherrilog.dart';
 export 'package:cherrilog/wrapper.dart';
 export 'package:cherrilog/formatter/timestamp.dart';
+export 'package:cherrilog/formatter/message.dart';
+export 'package:cherrilog/formatter/template.dart';
 export 'package:cherrilog/logger/logger.dart';
 export 'package:cherrilog/logger/loggers/logger_console.dart';
 export 'package:cherrilog/logger/loggers/logger_file.dart';
@@ -37,9 +39,5 @@ class CherriLog {
 
   void log(CherriMessage message) {
     logger.log(message);
-
-    // TODO: Implement flush interval
   }
 }
-
-extension CherriLogExtensions on CherriLog {}

--- a/lib/cherrilog.dart
+++ b/lib/cherrilog.dart
@@ -14,6 +14,7 @@ export 'package:cherrilog/logger/loggers/logger_console.dart';
 export 'package:cherrilog/logger/loggers/logger_file.dart';
 export 'package:cherrilog/level/log_level.dart';
 export 'package:cherrilog/level/log_level_ranges.dart';
+export 'package:cherrilog/model/message.dart';
 export 'package:cherrilog/model/options.dart';
 
 class CherriLog {

--- a/lib/cherrilog.dart
+++ b/lib/cherrilog.dart
@@ -4,7 +4,6 @@ import 'package:cherrilog/logger/logger.dart';
 import 'package:cherrilog/model/options.dart';
 import 'package:cherrilog/model/message.dart';
 
-export 'package:cherrilog/cherrilog.dart';
 export 'package:cherrilog/wrapper.dart';
 export 'package:cherrilog/formatter/timestamp.dart';
 export 'package:cherrilog/formatter/message.dart';

--- a/lib/formatter/message.dart
+++ b/lib/formatter/message.dart
@@ -75,6 +75,9 @@ class CherriFormatterMessageDefault extends CherriFormatterMessageBase<String> {
     if (message.error != null) {
       if (autoFormatTrace && stackTraceStyle == StackTraceStyle.tab) {
         formattedMessage += '\n\t${message.error}';
+      } else if (autoFormatTrace) {
+        // align mode: indent error line to the same column as stack frames.
+        formattedMessage += '\n${' ' * aheadLength}${message.error}';
       } else {
         formattedMessage += '\n${message.error}';
       }

--- a/lib/formatter/message.dart
+++ b/lib/formatter/message.dart
@@ -3,6 +3,22 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:cherrilog/formatter/timestamp.dart';
 import 'package:cherrilog/model/message.dart';
 
+/// Controls how stack trace frames are indented relative to the log body.
+///
+/// [StackTraceStyle.align] (default): each frame line is right-padded so it
+/// starts at the same column as the log message body.
+///
+/// [StackTraceStyle.tab]: each frame line starts on a new line with a single
+/// `\t` (tab) character as prefix, keeping the message body close to the
+/// log prefix.
+enum StackTraceStyle {
+  /// Right-align stack trace frames to the message body position.
+  align,
+
+  /// Place each stack frame on a new line with a single tab indent.
+  tab,
+}
+
 abstract class CherriFormatterMessageBase<T> {
   T format(CherriMessage message);
 }
@@ -15,6 +31,14 @@ class CherriFormatterMessageDefault extends CherriFormatterMessageBase<String> {
   bool autoFormatTrace;
   bool autoColorize;
 
+  /// Controls how stack trace frames are indented.
+  ///
+  /// - [StackTraceStyle.align] (default): frames right-aligned to the message body.
+  /// - [StackTraceStyle.tab]: each frame on a new line with a single `\t` prefix.
+  ///
+  /// Only effective when [autoFormatTrace] is `true`.
+  StackTraceStyle stackTraceStyle;
+
   CherriFormatterMessageDefault({
     this.timestampPattern = CherriFormatterTimeStampPattern.standardLongDateTime,
     this.costumeSplitter = '',
@@ -22,6 +46,7 @@ class CherriFormatterMessageDefault extends CherriFormatterMessageBase<String> {
     this.costumeSplitterClose = ']',
     this.autoFormatTrace = true,
     this.autoColorize = true,
+    this.stackTraceStyle = StackTraceStyle.align,
   });
 
   @override
@@ -41,21 +66,48 @@ class CherriFormatterMessageDefault extends CherriFormatterMessageBase<String> {
       formattedMessage += costumeSplitter + methodName;
     }
 
+    // NOTE: aheadLength must be computed before _colorize() below,
+    // because ANSI escape codes are invisible but count toward string length.
     var aheadLength = formattedMessage.length + costumeSplitter.length;
 
     formattedMessage += costumeSplitter + message.message;
 
+    if (message.error != null) {
+      if (autoFormatTrace && stackTraceStyle == StackTraceStyle.tab) {
+        formattedMessage += '\n\t${message.error}';
+      } else {
+        formattedMessage += '\n${message.error}';
+      }
+    }
+
     if (stackTrace != null) {
-      var frames = Trace.from(stackTrace).frames.toList();
+      final chain = Chain.forTrace(stackTrace);
 
-      frames.removeWhere((frame) => frame.package == 'cherrilog');
-
-      for (var frame in frames) {
-        formattedMessage += '\n';
-        if (autoFormatTrace) {
-          formattedMessage += ' ' * aheadLength;
+      for (final trace in chain.traces) {
+        // Add an async-gap separator when there are multiple traces.
+        if (trace != chain.traces.first) {
+          if (autoFormatTrace && stackTraceStyle == StackTraceStyle.tab) {
+            formattedMessage += '\n\t<asynchronous suspension>';
+          } else {
+            formattedMessage += '\n${' ' * aheadLength}<asynchronous suspension>';
+          }
         }
-        formattedMessage += frame.toString();
+
+        var frames = trace.frames.toList();
+
+        frames.removeWhere((frame) => frame.package == 'cherrilog');
+
+        for (var frame in frames) {
+          formattedMessage += '\n';
+          if (autoFormatTrace) {
+            if (stackTraceStyle == StackTraceStyle.tab) {
+              formattedMessage += '\t';
+            } else {
+              formattedMessage += ' ' * aheadLength;
+            }
+          }
+          formattedMessage += frame.toString();
+        }
       }
     }
 

--- a/lib/formatter/message.dart
+++ b/lib/formatter/message.dart
@@ -89,11 +89,8 @@ class CherriFormatterMessageDefault extends CherriFormatterMessageBase<String> {
       for (final trace in chain.traces) {
         // Add an async-gap separator when there are multiple traces.
         if (trace != chain.traces.first) {
-          if (autoFormatTrace && stackTraceStyle == StackTraceStyle.tab) {
-            formattedMessage += '\n\t<asynchronous suspension>';
-          } else {
-            formattedMessage += '\n${' ' * aheadLength}<asynchronous suspension>';
-          }
+          final gap = autoFormatTrace ? (stackTraceStyle == StackTraceStyle.tab ? '\t' : ' ' * aheadLength) : '';
+          formattedMessage += '\n$gap<asynchronous suspension>';
         }
 
         var frames = trace.frames.toList();
@@ -121,7 +118,8 @@ class CherriFormatterMessageDefault extends CherriFormatterMessageBase<String> {
     return formattedMessage;
   }
 
-  String _addCostumeSplitter(String? message) => message == null || message == '' ? '' : costumeSplitterOpen + message + costumeSplitterClose;
+  String _addCostumeSplitter(String? message) =>
+      message == null || message == '' ? '' : costumeSplitterOpen + message + costumeSplitterClose;
 
   String _colorize(String message, CherriLogLevel logLevel) {
     if (logLevel.ansiColor == null) return message;

--- a/lib/formatter/template.dart
+++ b/lib/formatter/template.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:cherrilog/formatter/message.dart';
 import 'package:cherrilog/formatter/timestamp.dart';
 import 'package:cherrilog/model/message.dart';
@@ -80,33 +82,36 @@ class CherriFormatterMessageTemplate extends CherriFormatterMessageBase<String> 
   }
 
   String _formatJson(CherriMessage message) {
-    final parts = <String>[
-      '"timestamp":"${CherriFormatterTimeStamp.format(message.timestamp, timestampPattern)}"',
-      '"level":"${message.logLevel.abbreviation}"',
-      '"levelName":"${message.logLevel.name}"',
-      '"message":"${_escapeJson(message.message)}"',
-    ];
+    final map = <String, String>{
+      'timestamp': CherriFormatterTimeStamp.format(message.timestamp, timestampPattern),
+      'level': message.logLevel.abbreviation,
+      'levelName': message.logLevel.name,
+      'message': message.message,
+    };
     if (message.className != null && message.className!.isNotEmpty) {
-      parts.add('"className":"${_escapeJson(message.className!)}"');
+      map['className'] = message.className!;
     }
     if (message.methodName != null && message.methodName!.isNotEmpty) {
-      parts.add('"methodName":"${_escapeJson(message.methodName!)}"');
+      map['methodName'] = message.methodName!;
     }
     if (message.error != null) {
-      parts.add('"error":"${_escapeJson(message.error.toString())}"');
+      map['error'] = message.error.toString();
     }
-    return '{${parts.join(',')}}';
-  }
-
-  String _escapeJson(String s) {
-    return s.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n').replaceAll('\r', '\\r').replaceAll('\t', '\\t');
+    if (message.stackTrace != null) {
+      map['stackTrace'] = _formatStackTrace(message.stackTrace);
+    }
+    return jsonEncode(map);
   }
 
   String _formatStackTrace(StackTrace? stackTrace) {
     if (stackTrace == null) return '';
     final chain = Chain.forTrace(stackTrace);
     final lines = <String>[];
-    final indent = (autoFormatTrace && stackTraceStyle == StackTraceStyle.tab) ? '\t' : '';
+    final indent = !autoFormatTrace
+        ? ''
+        : stackTraceStyle == StackTraceStyle.tab
+            ? '\t'
+            : '    '; // align mode → 4-space indent
     for (final trace in chain.traces) {
       if (trace != chain.traces.first) {
         lines.add('$indent<asynchronous suspension>');

--- a/lib/formatter/template.dart
+++ b/lib/formatter/template.dart
@@ -1,0 +1,121 @@
+import 'package:cherrilog/formatter/message.dart';
+import 'package:cherrilog/formatter/timestamp.dart';
+import 'package:cherrilog/model/message.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+/// A template-based message formatter that uses placeholders to control the
+/// output format.
+///
+/// Supported placeholders:
+/// - `{timestamp}` — the formatted timestamp (uses [timestampPattern])
+/// - `{level}` — log level abbreviation (e.g. `DBG`, `ERR`)
+/// - `{levelName}` — log level full name (e.g. `Debug`, `Error`)
+/// - `{message}` — the log message text
+/// - `{className}` — the calling class name (may be empty)
+/// - `{methodName}` — the calling method name (may be empty)
+/// - `{error}` — the error object (may be empty)
+/// - `{stackTrace}` — the formatted stack trace
+///
+/// Use the special value `"json"` as the template to output each log entry as a
+/// JSON object on a single line.
+///
+/// ```dart
+/// final fmt = CherriFormatterMessageTemplate('{timestamp} [{level}] {message}');
+/// ```
+class CherriFormatterMessageTemplate extends CherriFormatterMessageBase<String> {
+  /// The template string with optional placeholders.
+  final String template;
+
+  /// The timestamp pattern used by the `{timestamp}` placeholder.
+  final String timestampPattern;
+
+  /// Whether to colorize the output with ANSI escape codes.
+  final bool autoColorize;
+
+  /// Whether to format stack traces with aligned indentation.
+  final bool autoFormatTrace;
+
+  /// Controls how stack trace frames are indented.
+  ///
+  /// Only effective when [autoFormatTrace] is `true`.
+  final StackTraceStyle stackTraceStyle;
+
+  CherriFormatterMessageTemplate(
+    this.template, {
+    this.timestampPattern = CherriFormatterTimeStampPattern.standardLongDateTime,
+    this.autoColorize = true,
+    this.autoFormatTrace = true,
+    this.stackTraceStyle = StackTraceStyle.align,
+  });
+
+  @override
+  String format(CherriMessage message) {
+    if (template.toLowerCase() == 'json') {
+      return _formatJson(message);
+    }
+    return _formatTemplate(message);
+  }
+
+  String _formatTemplate(CherriMessage message) {
+    var result = template
+        .replaceAll('{timestamp}', CherriFormatterTimeStamp.format(message.timestamp, timestampPattern))
+        .replaceAll('{level}', message.logLevel.abbreviation)
+        .replaceAll('{levelName}', message.logLevel.name)
+        .replaceAll('{message}', message.message)
+        .replaceAll('{className}', message.className ?? '')
+        .replaceAll('{methodName}', message.methodName ?? '')
+        .replaceAll('{error}', message.error?.toString() ?? '');
+
+    // Handle stackTrace placeholder separately (it is multi-line).
+    if (template.contains('{stackTrace}')) {
+      final st = _formatStackTrace(message.stackTrace);
+      result = result.replaceAll('{stackTrace}', st);
+    }
+
+    if (autoColorize && message.logLevel.ansiColor != null) {
+      result = message.logLevel.ansiColorTemplate.replaceFirst('@message', result);
+    }
+
+    return result;
+  }
+
+  String _formatJson(CherriMessage message) {
+    final parts = <String>[
+      '"timestamp":"${CherriFormatterTimeStamp.format(message.timestamp, timestampPattern)}"',
+      '"level":"${message.logLevel.abbreviation}"',
+      '"levelName":"${message.logLevel.name}"',
+      '"message":"${_escapeJson(message.message)}"',
+    ];
+    if (message.className != null && message.className!.isNotEmpty) {
+      parts.add('"className":"${_escapeJson(message.className!)}"');
+    }
+    if (message.methodName != null && message.methodName!.isNotEmpty) {
+      parts.add('"methodName":"${_escapeJson(message.methodName!)}"');
+    }
+    if (message.error != null) {
+      parts.add('"error":"${_escapeJson(message.error.toString())}"');
+    }
+    return '{${parts.join(',')}}';
+  }
+
+  String _escapeJson(String s) {
+    return s.replaceAll('\\', '\\\\').replaceAll('"', '\\"').replaceAll('\n', '\\n').replaceAll('\r', '\\r').replaceAll('\t', '\\t');
+  }
+
+  String _formatStackTrace(StackTrace? stackTrace) {
+    if (stackTrace == null) return '';
+    final chain = Chain.forTrace(stackTrace);
+    final lines = <String>[];
+    final indent = (autoFormatTrace && stackTraceStyle == StackTraceStyle.tab) ? '\t' : '';
+    for (final trace in chain.traces) {
+      if (trace != chain.traces.first) {
+        lines.add('$indent<asynchronous suspension>');
+      }
+      for (final frame in trace.frames) {
+        if (frame.package == 'cherrilog') continue;
+        lines.add('$indent${frame.toString()}');
+      }
+    }
+    return lines.join('\n');
+  }
+}

--- a/lib/logger/logger.dart
+++ b/lib/logger/logger.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:cherrilog/cherrilog.dart';
-import 'package:cherrilog/model/message.dart';
 
 abstract class CherriLogger {
   late CherriOptions options;

--- a/lib/logger/logger.dart
+++ b/lib/logger/logger.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cherrilog/cherrilog.dart';
 import 'package:cherrilog/model/message.dart';
 
@@ -10,13 +12,34 @@ abstract class CherriLogger {
 
   final buffer = <String>[];
 
+  Timer? _flushTimer;
+
+  /// Schedules a deferred flush after [CherriOptions.flushInterval].
+  ///
+  /// Each call resets the timer so that rapid [pushLine] calls do not
+  /// trigger repeated flushes — only when the stream of writes pauses
+  /// for [CherriOptions.flushInterval] will the buffer be flushed.
+  void _scheduleFlush() {
+    _flushTimer?.cancel();
+    if (options.useBuffer) {
+      _flushTimer = Timer(options.flushInterval, () {
+        if (buffer.isNotEmpty) {
+          flush();
+          buffer.clear();
+        }
+      });
+    }
+  }
+
   void pushLine(String line) {
     buffer.add(line);
 
     if (options.useBuffer == false || buffer.length >= options.bufferLineLength) {
+      _flushTimer?.cancel();
       flush();
-
       buffer.clear();
+    } else {
+      _scheduleFlush();
     }
   }
 

--- a/lib/logger/loggers/logger_console.dart
+++ b/lib/logger/loggers/logger_console.dart
@@ -1,14 +1,29 @@
 ﻿import 'package:cherrilog/formatter/message.dart';
+import 'package:cherrilog/formatter/template.dart';
 import 'package:cherrilog/logger/logger.dart';
 import 'package:cherrilog/model/message.dart';
 
 class CherriConsole extends CherriLogger {
-  @override
-  void log(CherriMessage message) {
-    var formatter = CherriFormatterMessageDefault(
+  CherriFormatterMessageBase<String> _buildFormatter() {
+    if (options.formatTemplate != null) {
+      return CherriFormatterMessageTemplate(
+        options.formatTemplate!,
+        timestampPattern: options.timeStampPattern,
+        autoColorize: true,
+        autoFormatTrace: true,
+        stackTraceStyle: options.stackTraceStyle,
+      );
+    }
+    return CherriFormatterMessageDefault(
       timestampPattern: options.timeStampPattern,
       costumeSplitter: ' ',
+      stackTraceStyle: options.stackTraceStyle,
     );
+  }
+
+  @override
+  void log(CherriMessage message) {
+    var formatter = _buildFormatter();
 
     if (message.logLevel.inRange(options.logLevelRange)) {
       var formattedMessage = formatter.format(message).replaceAll("\r", "");

--- a/lib/logger/loggers/logger_file.dart
+++ b/lib/logger/loggers/logger_file.dart
@@ -1,4 +1,4 @@
-﻿import 'dart:io';
+import 'dart:io';
 
 import 'package:cherrilog/formatter/message.dart';
 import 'package:cherrilog/formatter/template.dart';
@@ -159,11 +159,7 @@ class CherriFile extends CherriLogger {
     var dir = Directory(location);
     if (!dir.existsSync()) return;
 
-    var files = dir
-        .listSync()
-        .whereType<File>()
-        .where((f) => f.path.endsWith('.log'))
-        .toList();
+    var files = dir.listSync().whereType<File>().where((f) => f.path.endsWith('.log')).toList();
 
     if (files.isEmpty) return;
 

--- a/lib/logger/loggers/logger_file.dart
+++ b/lib/logger/loggers/logger_file.dart
@@ -1,6 +1,7 @@
 ﻿import 'dart:io';
 
 import 'package:cherrilog/formatter/message.dart';
+import 'package:cherrilog/formatter/template.dart';
 import 'package:cherrilog/logger/logger.dart';
 import 'package:cherrilog/model/message.dart';
 import 'package:dart_art/dart_art.dart';
@@ -8,7 +9,35 @@ import 'package:dart_art/dart_art.dart';
 class CherriFile extends CherriLogger {
   late String fileNamePattern = '@yyyy-@MM-@dd-@HH-@id.log';
 
-  late String location = './logs';
+  /// Returns a sensible default log directory for the current platform.
+  ///
+  /// | Platform | Path |
+  /// |----------|------|
+  /// | Linux    | `$HOME/.local/share/cherrilog/logs` |
+  /// | macOS    | `$HOME/Library/Logs/cherrilog` |
+  /// | Windows  | `%APPDATA%/cherrilog/logs` |
+  /// | Android/iOS/Web | `./logs` (user should override) |
+  ///
+  /// Mobile and Web users should set [location] explicitly using a
+  /// platform-appropriate directory (e.g. via `path_provider` on Flutter).
+  static String get defaultLocation {
+    if (Platform.isWindows) {
+      final appData = Platform.environment['APPDATA'];
+      if (appData != null) return '$appData/cherrilog/logs';
+    }
+    if (Platform.isMacOS) {
+      final home = Platform.environment['HOME'];
+      if (home != null) return '$home/Library/Logs/cherrilog';
+    }
+    if (Platform.isLinux) {
+      final home = Platform.environment['HOME'];
+      if (home != null) return '$home/.local/share/cherrilog/logs';
+    }
+    // Android, iOS, Fuchsia, Web — fallback.
+    return './logs';
+  }
+
+  late String location = defaultLocation;
 
   late Duration shelfLife = const Duration(days: 20);
 
@@ -21,6 +50,12 @@ class CherriFile extends CherriLogger {
   late int clearMode = CherriFileClearMode.oldFiles | CherriFileClearMode.outSizedFiles;
 
   late int _fileId = 0;
+
+  /// Timestamp of the last cleanup run, used to throttle directory scans.
+  DateTime? _lastCleanup;
+
+  /// Minimum interval between two cleanup passes.
+  static const _cleanupThrottle = Duration(seconds: 60);
 
   CherriFile() {
     _fileId = getNextId();
@@ -64,13 +99,27 @@ class CherriFile extends CherriLogger {
     return fileName;
   }
 
-  @override
-  void log(CherriMessage message) {
-    var formatter = CherriFormatterMessageDefault(
+  CherriFormatterMessageBase<String> _buildFormatter() {
+    if (options.formatTemplate != null) {
+      return CherriFormatterMessageTemplate(
+        options.formatTemplate!,
+        timestampPattern: options.timeStampPattern,
+        autoColorize: false,
+        autoFormatTrace: true,
+        stackTraceStyle: options.stackTraceStyle,
+      );
+    }
+    return CherriFormatterMessageDefault(
       timestampPattern: options.timeStampPattern,
       costumeSplitter: ' ',
       autoColorize: false,
+      stackTraceStyle: options.stackTraceStyle,
     );
+  }
+
+  @override
+  void log(CherriMessage message) {
+    var formatter = _buildFormatter();
 
     if (message.logLevel.inRange(options.logLevelRange)) {
       var formattedMessage = formatter.format(message);
@@ -90,6 +139,67 @@ class CherriFile extends CherriLogger {
 
     var content = '${buffer.join('\n')}\n';
     file.writeAsStringSync(content, mode: FileMode.writeOnlyAppend);
+
+    _cleanupIfNeeded();
+  }
+
+  /// Performs log file cleanup according to the configured [clearMode].
+  ///
+  /// Cleanup is throttled to at most once per [_cleanupThrottle] to avoid
+  /// scanning the directory on every [flush] call.
+  void _cleanupIfNeeded() {
+    if (clearMode == 0) return;
+
+    final now = DateTime.now();
+    if (_lastCleanup != null && now.difference(_lastCleanup!) < _cleanupThrottle) {
+      return;
+    }
+    _lastCleanup = now;
+
+    var dir = Directory(location);
+    if (!dir.existsSync()) return;
+
+    var files = dir
+        .listSync()
+        .whereType<File>()
+        .where((f) => f.path.endsWith('.log'))
+        .toList();
+
+    if (files.isEmpty) return;
+
+    // Sort oldest first.
+    files.sort((a, b) => a.lastModifiedSync().compareTo(b.lastModifiedSync()));
+
+    // 1. Remove files older than shelfLife (oldFiles mode).
+    if ((clearMode & CherriFileClearMode.oldFiles) != 0) {
+      final cutoff = now.subtract(shelfLife);
+      files.removeWhere((f) {
+        if (f.lastModifiedSync().isBefore(cutoff)) {
+          f.deleteSync();
+          return true;
+        }
+        return false;
+      });
+    }
+
+    // 2. Keep only the newest maxFilesCount files.
+    while (files.length > maxFilesCount) {
+      files.removeAt(0).deleteSync();
+    }
+
+    // 3. Remove oldest files until total size is within limit (outSizedFiles mode).
+    if ((clearMode & CherriFileClearMode.outSizedFiles) != 0) {
+      var totalSize = files.fold<BigInt>(
+        BigInt.zero,
+        (sum, f) => sum + BigInt.from(f.lengthSync()),
+      );
+      final limit = maxSizeLimit.bytesCount;
+      while (totalSize > limit && files.isNotEmpty) {
+        final removed = files.removeAt(0);
+        totalSize -= BigInt.from(removed.lengthSync());
+        removed.deleteSync();
+      }
+    }
   }
 }
 

--- a/lib/logger/loggers/logger_file.dart
+++ b/lib/logger/loggers/logger_file.dart
@@ -16,10 +16,10 @@ class CherriFile extends CherriLogger {
   /// | Linux    | `$HOME/.local/share/cherrilog/logs` |
   /// | macOS    | `$HOME/Library/Logs/cherrilog` |
   /// | Windows  | `%APPDATA%/cherrilog/logs` |
-  /// | Android/iOS/Web | `./logs` (user should override) |
+  /// | Android/iOS | `./logs` (set via `path_provider` on Flutter) |
   ///
-  /// Mobile and Web users should set [location] explicitly using a
-  /// platform-appropriate directory (e.g. via `path_provider` on Flutter).
+  /// **Not available on Web** — [CherriFile] requires `dart:io`.
+  /// Use [CherriConsole] for logging on Web platforms.
   static String get defaultLocation {
     if (Platform.isWindows) {
       final appData = Platform.environment['APPDATA'];
@@ -47,7 +47,7 @@ class CherriFile extends CherriLogger {
 
   late BinarySize singleFileSizeLimit = BinarySize.parse('10 MB')!;
 
-  late int clearMode = CherriFileClearMode.oldFiles | CherriFileClearMode.outSizedFiles;
+  late int clearMode = CherriFileClearMode.oldFiles | CherriFileClearMode.outSizedFiles | CherriFileClearMode.maxFileCount;
 
   late int _fileId = 0;
 
@@ -182,9 +182,11 @@ class CherriFile extends CherriLogger {
       });
     }
 
-    // 2. Keep only the newest maxFilesCount files.
-    while (files.length > maxFilesCount) {
-      files.removeAt(0).deleteSync();
+    // 2. Keep only the newest maxFilesCount files (when maxFileCount flag is set).
+    if ((clearMode & CherriFileClearMode.maxFileCount) != 0) {
+      while (files.length > maxFilesCount) {
+        files.removeAt(0).deleteSync();
+      }
     }
 
     // 3. Remove oldest files until total size is within limit (outSizedFiles mode).
@@ -207,4 +209,6 @@ class CherriFileClearMode {
   static const oldFiles = 1;
 
   static const outSizedFiles = 2;
+
+  static const maxFileCount = 4;
 }

--- a/lib/model/message.dart
+++ b/lib/model/message.dart
@@ -7,6 +7,7 @@ class CherriMessage {
   String message;
   DateTime timestamp;
   StackTrace? stackTrace;
+  Object? error;
 
   CherriMessage(
     this.logLevel,
@@ -15,5 +16,6 @@ class CherriMessage {
     this.className,
     this.methodName,
     this.stackTrace,
+    this.error,
   });
 }

--- a/lib/model/options.dart
+++ b/lib/model/options.dart
@@ -1,4 +1,5 @@
 import 'package:cherrilog/formatter/message.dart';
+import 'package:cherrilog/formatter/template.dart';
 import 'package:cherrilog/formatter/timestamp.dart';
 import 'package:cherrilog/level/log_level.dart';
 import 'package:cherrilog/level/log_level_ranges.dart';

--- a/lib/model/options.dart
+++ b/lib/model/options.dart
@@ -1,3 +1,4 @@
+import 'package:cherrilog/formatter/message.dart';
 import 'package:cherrilog/formatter/timestamp.dart';
 import 'package:cherrilog/level/log_level.dart';
 import 'package:cherrilog/level/log_level_ranges.dart';
@@ -6,6 +7,25 @@ class CherriOptions {
   (CherriLogLevel, CherriLogLevel) logLevelRange = CherriLogLevelRanges.all;
 
   String timeStampPattern = CherriFormatterTimeStampPattern.standardLongDateTime;
+
+  /// An optional format template string.
+  ///
+  /// When set, loggers will use [CherriFormatterMessageTemplate] instead of
+  /// [CherriFormatterMessageDefault].
+  ///
+  /// Supported placeholders: `{timestamp}`, `{level}`, `{levelName}`,
+  /// `{message}`, `{className}`, `{methodName}`, `{error}`, `{stackTrace}`.
+  ///
+  /// Use `"json"` for single-line JSON output.
+  ///
+  /// When `null` (the default), the built-in default format is used.
+  String? formatTemplate;
+
+  /// Controls how stack trace frames are indented.
+  ///
+  /// - [StackTraceStyle.align] (default): frames right-aligned to the message body.
+  /// - [StackTraceStyle.tab]: each frame on a new line with a single `\t` prefix.
+  StackTraceStyle stackTraceStyle = StackTraceStyle.align;
 
   bool useBuffer = true;
 

--- a/lib/model/options.dart
+++ b/lib/model/options.dart
@@ -32,5 +32,12 @@ class CherriOptions {
 
   int bufferLineLength = 30;
 
+  /// When `true` (default), Dart core library frames (`package == null`) are
+  /// skipped when auto-detecting the caller's [className] and [methodName].
+  ///
+  /// Set to `false` to allow Dart core frames to be reported as the caller
+  /// (rarely useful; mostly for debugging the frame detection itself).
+  bool filterCoreFrames = true;
+
   Duration flushInterval = const Duration(milliseconds: 500);
 }

--- a/lib/wrapper.dart
+++ b/lib/wrapper.dart
@@ -1,5 +1,4 @@
 ﻿import 'package:cherrilog/cherrilog.dart';
-import 'package:cherrilog/model/message.dart';
 import 'package:stack_trace/stack_trace.dart';
 
 /// Extracts the class name from a stack frame member string.
@@ -50,7 +49,7 @@ void warning(String message, {Object? error, StackTrace? stackTrace}) {
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),
     error: error,
-    stackTrace: stackTrace ?? StackTrace.current,
+    stackTrace: stackTrace,
   ));
 }
 
@@ -60,7 +59,7 @@ void info(String message, {Object? error, StackTrace? stackTrace}) {
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),
     error: error,
-    stackTrace: stackTrace ?? StackTrace.current,
+    stackTrace: stackTrace,
   ));
 }
 
@@ -70,6 +69,6 @@ void debug(String message, {Object? error, StackTrace? stackTrace}) {
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),
     error: error,
-    stackTrace: stackTrace ?? StackTrace.current,
+    stackTrace: stackTrace,
   ));
 }

--- a/lib/wrapper.dart
+++ b/lib/wrapper.dart
@@ -1,22 +1,75 @@
 ﻿import 'package:cherrilog/cherrilog.dart';
 import 'package:cherrilog/model/message.dart';
+import 'package:stack_trace/stack_trace.dart';
+
+/// Extracts the class name from a stack frame member string.
+///
+/// [Frame.member] is typically `ClassName.methodName` or just `functionName`.
+String? _extractClassName(Frame frame) {
+  final member = frame.member;
+  if (member == null || member.isEmpty) return null;
+  final dotIndex = member.indexOf('.');
+  return dotIndex > 0 ? member.substring(0, dotIndex) : null;
+}
+
+/// Returns the full member signature from a stack frame.
+String? _extractMethodName(Frame frame) => frame.member;
+
+/// Finds the first caller frame outside the cherrilog package.
+Frame _findCallerFrame() {
+  final trace = Trace.current();
+  for (final frame in trace.frames) {
+    if (frame.package != 'cherrilog') return frame;
+  }
+  return trace.frames.first;
+}
 
 void fatal(String message, {Object? error, StackTrace? stackTrace}) {
-  CherriLog.instance?.log(CherriMessage(CherriLogLevel.fatal, message, DateTime.now()));
+  final caller = _findCallerFrame();
+  CherriLog.instance?.log(CherriMessage(CherriLogLevel.fatal, message, DateTime.now(),
+    className: _extractClassName(caller),
+    methodName: _extractMethodName(caller),
+    error: error,
+    stackTrace: stackTrace ?? StackTrace.current,
+  ));
 }
 
 void error(String message, {Object? error, StackTrace? stackTrace}) {
-  CherriLog.instance?.log(CherriMessage(CherriLogLevel.error, message, DateTime.now()));
+  final caller = _findCallerFrame();
+  CherriLog.instance?.log(CherriMessage(CherriLogLevel.error, message, DateTime.now(),
+    className: _extractClassName(caller),
+    methodName: _extractMethodName(caller),
+    error: error,
+    stackTrace: stackTrace ?? StackTrace.current,
+  ));
 }
 
 void warning(String message, {Object? error, StackTrace? stackTrace}) {
-  CherriLog.instance?.log(CherriMessage(CherriLogLevel.warning, message, DateTime.now()));
+  final caller = _findCallerFrame();
+  CherriLog.instance?.log(CherriMessage(CherriLogLevel.warning, message, DateTime.now(),
+    className: _extractClassName(caller),
+    methodName: _extractMethodName(caller),
+    error: error,
+    stackTrace: stackTrace ?? StackTrace.current,
+  ));
 }
 
 void info(String message, {Object? error, StackTrace? stackTrace}) {
-  CherriLog.instance?.log(CherriMessage(CherriLogLevel.info, message, DateTime.now()));
+  final caller = _findCallerFrame();
+  CherriLog.instance?.log(CherriMessage(CherriLogLevel.info, message, DateTime.now(),
+    className: _extractClassName(caller),
+    methodName: _extractMethodName(caller),
+    error: error,
+    stackTrace: stackTrace ?? StackTrace.current,
+  ));
 }
 
 void debug(String message, {Object? error, StackTrace? stackTrace}) {
-  CherriLog.instance?.log(CherriMessage(CherriLogLevel.debug, message, DateTime.now()));
+  final caller = _findCallerFrame();
+  CherriLog.instance?.log(CherriMessage(CherriLogLevel.debug, message, DateTime.now(),
+    className: _extractClassName(caller),
+    methodName: _extractMethodName(caller),
+    error: error,
+    stackTrace: stackTrace ?? StackTrace.current,
+  ));
 }

--- a/lib/wrapper.dart
+++ b/lib/wrapper.dart
@@ -15,16 +15,23 @@ String? _extractClassName(Frame frame) {
 String? _extractMethodName(Frame frame) => frame.member;
 
 /// Finds the first caller frame outside the cherrilog package.
-Frame _findCallerFrame() {
+///
+/// Always skips frames from `cherrilog` and `stack_trace` packages.
+/// When [filterCoreFrames] is `true` (default), Dart core library frames
+/// (`package == null`) are also skipped.
+Frame _findCallerFrame({bool filterCoreFrames = true}) {
   final trace = Trace.current();
   for (final frame in trace.frames) {
-    if (frame.package != 'cherrilog') return frame;
+    final pkg = frame.package;
+    if (pkg == 'cherrilog' || pkg == 'stack_trace') continue;
+    if (filterCoreFrames && pkg == null) continue;
+    return frame;
   }
   return trace.frames.first;
 }
 
 void fatal(String message, {Object? error, StackTrace? stackTrace}) {
-  final caller = _findCallerFrame();
+  final caller = _findCallerFrame(filterCoreFrames: CherriLog.instance?.options.filterCoreFrames ?? true);
   CherriLog.instance?.log(CherriMessage(CherriLogLevel.fatal, message, DateTime.now(),
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),
@@ -34,7 +41,7 @@ void fatal(String message, {Object? error, StackTrace? stackTrace}) {
 }
 
 void error(String message, {Object? error, StackTrace? stackTrace}) {
-  final caller = _findCallerFrame();
+  final caller = _findCallerFrame(filterCoreFrames: CherriLog.instance?.options.filterCoreFrames ?? true);
   CherriLog.instance?.log(CherriMessage(CherriLogLevel.error, message, DateTime.now(),
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),
@@ -44,7 +51,7 @@ void error(String message, {Object? error, StackTrace? stackTrace}) {
 }
 
 void warning(String message, {Object? error, StackTrace? stackTrace}) {
-  final caller = _findCallerFrame();
+  final caller = _findCallerFrame(filterCoreFrames: CherriLog.instance?.options.filterCoreFrames ?? true);
   CherriLog.instance?.log(CherriMessage(CherriLogLevel.warning, message, DateTime.now(),
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),
@@ -54,7 +61,7 @@ void warning(String message, {Object? error, StackTrace? stackTrace}) {
 }
 
 void info(String message, {Object? error, StackTrace? stackTrace}) {
-  final caller = _findCallerFrame();
+  final caller = _findCallerFrame(filterCoreFrames: CherriLog.instance?.options.filterCoreFrames ?? true);
   CherriLog.instance?.log(CherriMessage(CherriLogLevel.info, message, DateTime.now(),
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),
@@ -64,7 +71,7 @@ void info(String message, {Object? error, StackTrace? stackTrace}) {
 }
 
 void debug(String message, {Object? error, StackTrace? stackTrace}) {
-  final caller = _findCallerFrame();
+  final caller = _findCallerFrame(filterCoreFrames: CherriLog.instance?.options.filterCoreFrames ?? true);
   CherriLog.instance?.log(CherriMessage(CherriLogLevel.debug, message, DateTime.now(),
     className: _extractClassName(caller),
     methodName: _extractMethodName(caller),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ">=3.3.0 <4.0.0"
 
 dependencies:
-  dart_art: ^0.1.1
+  dart_art: ^0.2.1
   intl: ^0.20.0
   stack_trace: ^1.11.1
 
 dev_dependencies:
-  lints: ^5.1.1
+  lints: ^6.1.0
   test: ^1.24.0
 
 platforms:

--- a/test/cherrilog_test.dart
+++ b/test/cherrilog_test.dart
@@ -77,17 +77,24 @@ void main() {
     });
 
     test('error with stackTrace prints frames aligned to body', () {
-      // In align mode, stack frames are right-padded with spaces so they
-      // start at the same column as the message body.
-      // On screen you'll see:
-      //   [timestamp] [ERR] [cls] [mtd] message body
-      //                                  frame:1 ...
-      //                                  frame:2 ...
+      // Visual output (keep for human inspection).
       error(
         'error message with align style',
         error: Exception('test error'),
         stackTrace: StackTrace.current,
       );
+
+      // Assert: formatter output has right-aligned frames (spaces before frame text).
+      final fmt = CherriFormatterMessageDefault(stackTraceStyle: StackTraceStyle.align);
+      final msg = CherriMessage(CherriLogLevel.error, 'test', DateTime(2025, 1, 1),
+        error: Exception('boom'),
+        stackTrace: StackTrace.current,
+      );
+      final output = fmt.format(msg);
+      final frameLines = output.split('\n').where((l) => l.contains('cherrilog_test.dart'));
+      expect(frameLines.isNotEmpty, isTrue);
+      // At least one frame should start with significant right-padding.
+      expect(frameLines.any((l) => l.startsWith(' ' * 20)), isTrue);
     });
   });
 
@@ -105,17 +112,26 @@ void main() {
     });
 
     test('error with stackTrace prints frames with tab indent', () {
-      // In tab mode, each stack frame starts on a new line with a '\t' prefix.
-      // The message body stays close to the prefix, and frames are indented
-      // by a single tab character:
-      //   [timestamp] [ERR] [cls] [mtd] message body
-      //   	frame:1 ...
-      //   	frame:2 ...
+      // Visual output (keep for human inspection).
       error(
         'error message with tab style',
         error: Exception('test error'),
         stackTrace: StackTrace.current,
       );
+
+      // Assert: formatter output has tab-indented frames.
+      final fmt = CherriFormatterMessageDefault(stackTraceStyle: StackTraceStyle.tab);
+      final msg = CherriMessage(CherriLogLevel.error, 'test', DateTime(2025, 1, 1),
+        error: Exception('boom'),
+        stackTrace: StackTrace.current,
+      );
+      final output = fmt.format(msg);
+      final frameLines = output.split('\n').where((l) => l.contains('cherrilog_test.dart'));
+      expect(frameLines.isNotEmpty, isTrue);
+      // Every frame line should start with a tab.
+      for (final line in frameLines) {
+        expect(line, startsWith('\t'));
+      }
     });
   });
 }

--- a/test/cherrilog_test.dart
+++ b/test/cherrilog_test.dart
@@ -62,4 +62,60 @@ void main() {
       }
     });
   });
+
+  group('StackTraceStyle.align — frames right-aligned to message body', () {
+    setUp(() {
+      CherriLog.init(
+        options: CherriOptions()
+          ..logLevelRange = CherriLogLevelRanges.all
+          ..timeStampPattern = CherriFormatterTimeStampPattern.standardLongDateTime
+          ..useBuffer = false
+          ..stackTraceStyle = StackTraceStyle.align,
+      ).logTo(CherriConsole());
+
+      expect(CherriLog.instance, isNotNull);
+    });
+
+    test('error with stackTrace prints frames aligned to body', () {
+      // In align mode, stack frames are right-padded with spaces so they
+      // start at the same column as the message body.
+      // On screen you'll see:
+      //   [timestamp] [ERR] [cls] [mtd] message body
+      //                                  frame:1 ...
+      //                                  frame:2 ...
+      error(
+        'error message with align style',
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+      );
+    });
+  });
+
+  group('StackTraceStyle.tab — frames with tab indent on new line', () {
+    setUp(() {
+      CherriLog.init(
+        options: CherriOptions()
+          ..logLevelRange = CherriLogLevelRanges.all
+          ..timeStampPattern = CherriFormatterTimeStampPattern.standardLongDateTime
+          ..useBuffer = false
+          ..stackTraceStyle = StackTraceStyle.tab,
+      ).logTo(CherriConsole());
+
+      expect(CherriLog.instance, isNotNull);
+    });
+
+    test('error with stackTrace prints frames with tab indent', () {
+      // In tab mode, each stack frame starts on a new line with a '\t' prefix.
+      // The message body stays close to the prefix, and frames are indented
+      // by a single tab character:
+      //   [timestamp] [ERR] [cls] [mtd] message body
+      //   	frame:1 ...
+      //   	frame:2 ...
+      error(
+        'error message with tab style',
+        error: Exception('test error'),
+        stackTrace: StackTrace.current,
+      );
+    });
+  });
 }


### PR DESCRIPTION
This pull request introduces major enhancements to the CherriLog logging package, focusing on improved formatting flexibility, better error and stack trace handling, and smarter log file management. The most significant changes are the addition of a template-based formatter with JSON support, improved stack trace formatting options, automatic inclusion of caller information in wrapper functions, and a more robust file logger with platform-specific defaults and throttled cleanup.

**Formatter and Output Customization**

* Added a new `CherriFormatterMessageTemplate` class that allows users to specify a custom log format string with placeholders (including support for JSON output via the `"json"` template). This enables highly customizable log message formatting. (`lib/formatter/template.dart`, `lib/model/options.dart`, `lib/logger/loggers/logger_console.dart`, `lib/logger/loggers/logger_file.dart`) [[1]](diffhunk://#diff-ece6a2947d0df147e01af7293b213ee47185e44d1b3e9eed2c50b56c4b924946R1-R121) [[2]](diffhunk://#diff-2173dc6608f6404bc2692b0caf46ad5c3ef229eadb7084087b618c678b3b38cfR1) [[3]](diffhunk://#diff-2173dc6608f6404bc2692b0caf46ad5c3ef229eadb7084087b618c678b3b38cfR11-R29) [[4]](diffhunk://#diff-ca3da93821f0f2d05c124b848b31b08ec3131cbbda9865c11ac14aaef4c90c79R2-R26) [[5]](diffhunk://#diff-4b7eecee698ec712cc15cd350c189389be308d949b13a64f3d41b92523546748L67-R122) [[6]](diffhunk://#diff-ca3da93821f0f2d05c124b848b31b08ec3131cbbda9865c11ac14aaef4c90c79R2-R26) [[7]](diffhunk://#diff-c1b848ff0f725d8903a742721ce7fea489200e40bb537581ffcb994e0b4c9781R10-R11)
* Introduced the `StackTraceStyle` enum and related options to control how stack traces are indented in log output, supporting both aligned and tab-indented styles. (`lib/formatter/message.dart`, `lib/model/options.dart`) [[1]](diffhunk://#diff-70539bcac4b91104a5efbcfd91a3ae4b316eb246de76eadf30e8999532135ef0R6-R21) [[2]](diffhunk://#diff-70539bcac4b91104a5efbcfd91a3ae4b316eb246de76eadf30e8999532135ef0R34-R49) [[3]](diffhunk://#diff-2173dc6608f6404bc2692b0caf46ad5c3ef229eadb7084087b618c678b3b38cfR11-R29)

**Error and Stack Trace Handling**

* The `CherriMessage` model now includes an `error` field, and all wrapper logging functions (`fatal`, `error`, `warning`, `info`, `debug`) automatically capture caller class/method names and stack traces using the `stack_trace` package. (`lib/model/message.dart`, `lib/wrapper.dart`) [[1]](diffhunk://#diff-06dec1e8a5920adf1915da877b9e4948b6b1cb7648ade331e6e3c722a0ba4155R10) [[2]](diffhunk://#diff-06dec1e8a5920adf1915da877b9e4948b6b1cb7648ade331e6e3c722a0ba4155R19) [[3]](diffhunk://#diff-a8a1ace4237c37328680b52ed6345ad8c10e7cb20311fc60be8c0960cf72e5f2R3-R74)
* Log formatters and templates now support an `{error}` placeholder and improved multi-line stack trace formatting. (`lib/formatter/message.dart`, `lib/formatter/template.dart`) [[1]](diffhunk://#diff-70539bcac4b91104a5efbcfd91a3ae4b316eb246de76eadf30e8999532135ef0R69-R112) [[2]](diffhunk://#diff-ece6a2947d0df147e01af7293b213ee47185e44d1b3e9eed2c50b56c4b924946R1-R121)

**File Logger Improvements**

* The file logger (`CherriFile`) now uses a platform-appropriate default log directory (e.g., `$HOME/Library/Logs/cherrilog` on macOS, `%APPDATA%/cherrilog/logs` on Windows) and exposes this as a static method. (`lib/logger/loggers/logger_file.dart`)
* Log file cleanup is now throttled to avoid excessive directory scans, and supports removing old files, limiting file count, and enforcing a maximum total size according to configurable modes. (`lib/logger/loggers/logger_file.dart`) [[1]](diffhunk://#diff-4b7eecee698ec712cc15cd350c189389be308d949b13a64f3d41b92523546748R54-R59) [[2]](diffhunk://#diff-4b7eecee698ec712cc15cd350c189389be308d949b13a64f3d41b92523546748R142-R202)

**Buffering and Flushing**

* The logger base class now supports a deferred flush mechanism: when buffering is enabled, flush is triggered after a configurable interval of inactivity, rather than on every log message. (`lib/logger/logger.dart`) [[1]](diffhunk://#diff-fbe32870a65dd7d024341feb2a3d4afee9d795e04af90eb8ab9f3fc5cc6d6c21R1-R2) [[2]](diffhunk://#diff-fbe32870a65dd7d024341feb2a3d4afee9d795e04af90eb8ab9f3fc5cc6d6c21R15-R42)

These changes significantly improve the flexibility, usability, and performance of the CherriLog package, making it easier to customize log output and manage log files efficiently.

Now, the result of `dart test` belike:

<img width="1832" height="1485" alt="image" src="https://github.com/user-attachments/assets/c37379e9-3805-4ca9-90b5-5f4d86391331" />
